### PR TITLE
feat(cli): model generator can now pick properties from config file

### DIFF
--- a/examples/redis-cache/package.json
+++ b/examples/redis-cache/package.json
@@ -38,16 +38,21 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/loopbackio/loopback-next.git",
+    "directory": "examples/redis-cache"
   },
-  "author": "Awais Saeed <awaissaeed530@gmail.com>",
-  "license": "",
+  "license": "MIT",
+  "author": "IBM Corp.",
+  "copyright.owner": "IBM Corp.",
   "files": [
     "README.md",
     "dist",
     "src",
     "!*/__tests__"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@loopback/boot": "^4.1.0",
     "@loopback/core": "^3.1.0",

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -350,6 +350,12 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
   async promptPropertyName() {
     if (this.shouldExit()) return false;
 
+    // If properties are provided from config file
+    if (this.options.properties) {
+      Object.assign(this.artifactInfo.properties, this.options.properties);
+      return;
+    }
+
     this.log(g.f('Enter an empty property name when done'));
     this.log();
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -309,4 +309,24 @@ describe('model generator using --config option', () => {
       );
     });
   });
+
+  describe('model generator using --config option with properties', () => {
+    it('creates a model with properties', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+        .withArguments([
+          '--config',
+          '{"name":"test", "base":"Entity", \
+          "properties": { \
+            "id": {"type": "string", "id": true, "generated": true, "required": true}, \
+            "name": {"type": "string", "required": true, "default": "xyz"}}}',
+          '--yes',
+        ]);
+
+      basicModelFileChecks(expectedModelFile, expectedIndexFile);
+
+      assert.fileContent(expectedModelFile, /id: string;/);
+    });
+  });
 });


### PR DESCRIPTION
You can now provide properties in the model config file in this format.

```sh
{
  "name": "product",
  "base": "Entity",
  "properties": {
    "id": {
      "type": "string",
      "id": true,
      "generated": true,
      "required": true
    },
    "name": {
      "type": "string",
      "required": true,
      "default": "xyz"
    }
  }
}
```